### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ self.textField.numericFormatter = [AKNumericFormatter formatterWithMask:@"+*(***
 ```
 Yep, it's easy and no subclassing.
 
-###iOS 5 Compatibility
+### iOS 5 Compatibility
 
 It's working on iOS 5, but you should help it a little bit. Call `alertDeleteBackwards` method
 in your `UITextField` delegate's `shouldChangeCharactersInRange:replacementString:` method


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
